### PR TITLE
fix docker image name in examples

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -16,7 +16,7 @@ The above command is going to pull down the docker image from the Docker Hub. It
 After the download is complete, to run this container to start up a notebook server over HTTPS.
 
 ```
-docker run -d -p 443:8888 -e "PASSWORD=Apa$$word" ipython/notebook
+docker run -d -p 443:8888 -e "PASSWORD=Apa$$word" somyamohanty/datascience
 ```
 
 You'll now be able to access your notebook at https://localhost with password Apa$$word (please change the environment variable above).
@@ -27,4 +27,4 @@ you can use the `USE_HTTP` environment variable.  Setting it to a non-zero value
 
 Example:
 ```
-docker run -d -p 80:8888 -e "PASSWORD=MakeAPassword" -e "USE_HTTP=1" ipython/notebook
+docker run -d -p 80:8888 -e "PASSWORD=MakeAPassword" -e "USE_HTTP=1" somyamohanty/datascience


### PR DESCRIPTION
Hi, Dr Mohanty,

This PR fixes the name in the docker examples. 